### PR TITLE
Fix npm start script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "start": "npm run frontend & npm run copy-settings && npm run backend",
-    "start-windows": "&& start /B npm run frontend-windows && npm run copy-settings-windows && npm run backend-windows",
+    "start-windows": "start /B npm run frontend-windows && npm run copy-settings-windows && npm run backend-windows",
     "frontend": "webpack --config events_frontend/webpack.dev.js --watch",
     "frontend-windows": "webpack --config \"events_frontend\\webpack.dev.js\" --watch",
     "lint": "eslint .",


### PR DESCRIPTION
# Description

Remove the extra `&& ` at the beginning of `start-windows` script.

# How Has This Been Tested?

Run `npm run start-windows` in windows.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
