### PR TITLE
Fixed image upload errors.

### DIFF
--- a/events_backend/app/serializers.py
+++ b/events_backend/app/serializers.py
@@ -22,6 +22,18 @@ class OrgSerializer(serializers.ModelSerializer):
         except KeyError:
             return ""
 
+    def to_representation(self, instance):
+        """Convert `username` to lowercase."""
+        ret = super().to_representation(instance)
+        for photo in ret["photo"]:
+            photo["link"] = (
+                "https://"
+                + settings.AWS_STORAGE_BUCKET_NAME
+                + ".s3.amazonaws.com/"
+                + photo["link"]
+            )
+        return ret
+
 
 class EventSerializer(serializers.ModelSerializer):
     class Meta:
@@ -80,7 +92,8 @@ class UpdatedOrgSerializer(serializers.Serializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    org = serializers.PrimaryKeyRelatedField(many=True, queryset=Org.objects.all())
+    org = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=Org.objects.all())
     owner = serializers.ReadOnlyField(source="owner.username")
 
     class Meta:

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -38,6 +38,7 @@ from .models import (
     Attendance,
     Event_Media,
     Event_Tags,
+    Org_Media,
     Verified_Emails,
 )
 from .serializers import (
@@ -157,6 +158,11 @@ class UserProfile(APIView):
         org_set.name = orgData["name"]
         org_set.website = orgData["website"]
         org_set.bio = orgData["bio"]
+
+        if orgData["imageUrl"] != "":
+            media = Media.objects.create(link=orgData["imageUrl"], uploaded_by=org_set)
+            org_media = Org_Media(org=org_set, media=media)
+            org_media.save()
 
         org_set.save()
 


### PR DESCRIPTION
### Summary

Reason for the change:
Organizations could not change their profile picture for some reason. It would upload but would never be returned in a call.

### Test Plan

We have tested this on device on my local machine using a local front-end and backend and the live database. It worked perfectly and registered in the api calls.

# Description
Fixed the issues with organizers not being able to upload their profile photo to the database.