### PR TITLE
Fixed get all tags API endpoint

### DIFF
--- a/events_backend/app/urls.py
+++ b/events_backend/app/urls.py
@@ -53,6 +53,8 @@ urlpatterns = [
         name='All Location Details'),
     url(r'^tag/(?P<tag_id>[0-9]+)/$',
         views.SingleTagDetail.as_view(), name='Single Tag Details'),
+    url(r'^tag/all/$',
+        views.GetAllTags.as_view(), name='All Tag Details'),
 
     url(r'^media/(?P<img_id>[0-9]+)/$',
         views.ImageDetail.as_view(), name='Media Detail'),

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -339,7 +339,7 @@ class DeleteEvents(APIView):
 # edit tags doesnt workd
 class GetEvents(APIView):
     authentication_classes = (SessionAuthentication,)
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = ()
 
     def get(self, request, page, format=None):
         org = request.user.org
@@ -353,7 +353,7 @@ class GetEvents(APIView):
 class GetAllTags(APIView):
     # TODO: alter classes to token and admin?
     authentication_classes = (SessionAuthentication,)
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = ()
 
     def get(self, request, format=None):
         tags = Tag.objects.all()


### PR DESCRIPTION
### Summary

Reason for the change:

Get all tags endpoint was broken. Not returning anything.

### Test Plan
Ran on local machine and did various tests, and it did return all possible tag options currently.