### PR TITLE
Fixed get all tags returning raw json list instead of object wrapping…

### DIFF
--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -358,7 +358,7 @@ class GetAllTags(APIView):
     def get(self, request, format=None):
         tags = Tag.objects.all()
         serializer = TagSerializer(tags, many=True)
-        return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
+        return JsonResponse({"tags":serializer.data}, safe=False, status=status.HTTP_200_OK)
 
 
 # =============================================================


### PR DESCRIPTION
### Summary

Reason for the change:

Need in order to use JSONObjectResponse because the JSONObject cannot be a JSONArray as well.

### Test Plan
Tested on local machine with local API on live database.