### PR TITLE
Made feed/events endpoint more flexible, making the <page> input opti…

### DIFF
--- a/events_backend/app/serializers.py
+++ b/events_backend/app/serializers.py
@@ -84,7 +84,11 @@ class TagSerializer(serializers.ModelSerializer):
 class UpdatedEventsSerializer(serializers.Serializer):
     events = serializers.JSONField()  # pass in serialized events
     timestamp = serializers.DateTimeField()
+    page = serializers.IntegerField()
     pages = serializers.IntegerField()
+    pageSize = serializers.IntegerField()
+    totalEventCount = serializers.IntegerField()
+
 
 class UpdatedOrgSerializer(serializers.Serializer):
     orgs = serializers.JSONField()  # pass in serialized events

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -524,24 +524,51 @@ class EventFeed(APIView):
     def get(self, request, format=None):
         start_time = request.GET.get("start")
         end_time = request.GET.get("end")
-        page = int(request.GET.get("page"))
+
+        pageSize = -1
+        pageSizeFound = False
+        try:
+            pageSize = int(request.GET.get("pageSize"))
+            pageSizeFound = True
+        except:
+            pageSize = EVENTS_PER_PAGE
+
+        try:
+            page = int(request.GET.get("page"))
+        except:
+            if(pageSizeFound):
+                page = 1
+            else:
+                allSerializer = EventSerializer(Event.objects.all(), many=True)
+                serializer = UpdatedEventsSerializer({
+                    "events": allSerializer.data,
+                    "timestamp": timezone.now(),
+                    "page": 1,
+                    "pages": 1,
+                    "pageSize": Event.objects.count(),
+                    "totalEventCount": Event.objects.count()
+                })
+                return JsonResponse(serializer.data, status=status.HTTP_200_OK)
 
         start_time = dateutil.parser.parse(start_time)
         end_time = dateutil.parser.parse(end_time)
         filtered_events, all_deleted = outdatedEvents(start_time, end_time)
         # pagination; Report back the chunk of events represented by page=_
         json_events = EventSerializer(filtered_events, many=True).data
-        total_pages = int(round(len(json_events) / EVENTS_PER_PAGE))
+        total_pages = int(math.ceil((len(json_events) / pageSize)))
 
         # "page" is constrained to 1 and the last page (total_pages)
         page = max(min(total_pages, page), 1)
 
-        this_page_events = json_events[(page - 1) * EVENTS_PER_PAGE: page * EVENTS_PER_PAGE]
+        this_page_events = json_events[(page - 1) * pageSize: page * pageSize]
 
         serializer = UpdatedEventsSerializer({
             "events": this_page_events,
             "timestamp": timezone.now(),
-            "pages": total_pages
+            "page": page,
+            "pages": total_pages,
+            "pageSize": pageSize,
+            "totalEventCount": Event.objects.count()
         })
         return JsonResponse(serializer.data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
### Summary

The event feed endpoint was restricted to require multiple extra parameters that the mobile end didn't need to use, so I made the <page> param optional, and added another optional parameter <pageSize>. The behavior is specified below:

Made feed/events endpoint more flexible, making the <page> input optional (returning all eventsts when no page or pageSize is specified) and adding optional <pageSize> that will default to 15 if not specified, and if <pageSize> is specified without a <page> input (the index essentially), the page is just considered to be the first, 1, with the pagination occuring with the specified <pageSize>.

### Test Plan

I have tested on my local machine to prove that each possible version of the endpoint is tried and tested.

### Notes

This does not require any changes from any other codebase, and the endpoint is more flexible.
