### PR TITLE
Fixed critical frontend issue that broke frontend when a backend endp…

### DIFF
--- a/events_backend/app/api_urls.py
+++ b/events_backend/app/api_urls.py
@@ -9,6 +9,8 @@ from . import views
 urlpatterns = [
     # login/signup
     url(r"^signup/$", ensure_csrf_cookie(views.SignUp.as_view()), name="Sign-Up"),
+    url(r"^get_events/$",
+        views.GetEvents.as_view(), name="Get-Events"),
     url(r"^login/$", ensure_csrf_cookie(views.Login.as_view()), name="Login"),
     url(r"^loggedin/$", views.check_login_status, name="Check-Login"),
     # profile

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -336,6 +336,15 @@ class DeleteEvents(APIView):
         else:
             return HttpResponse(status=status.HTTP_401_UNAUTHORIZED)
 
+class GetEvents(APIView):
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = ()
+
+    def post(self, request, format=None):
+        org = request.user.org
+        event_set = Event.objects.filter(organizer=org)
+        serializer = EventSerializer(event_set, many=True)
+        return JsonResponse({"events":serializer.data}, safe=False, status=status.HTTP_200_OK)
 
 class GetAllTags(APIView):
     # TODO: alter classes to token and admin?

--- a/events_frontend/src/MyEvents.js
+++ b/events_frontend/src/MyEvents.js
@@ -31,11 +31,12 @@ class MyEvents extends Component {
 
   retrievePageEvents() {
     axios
-      .get(`/api/get_events/${parseInt(this.props.match.params.id) || 1}/`)
+      .post(`/api/get_events/`)
       .then(response => {
+        console.log(response);
         this.setState({
           events: response.data.events,
-          lastPage: response.data.last_page
+          lastPage: response.data.pages
         });
       })
       .catch(error => {
@@ -178,9 +179,9 @@ class MyEvents extends Component {
               let imageUrl =
                 event.media.length > 0
                   ? event.media.sort(
-                      (a, b) =>
-                        Date.parse(b.uploaded_at) - Date.parse(a.uploaded_at)
-                    )[0].link
+                    (a, b) =>
+                      Date.parse(b.uploaded_at) - Date.parse(a.uploaded_at)
+                  )[0].link
                   : "";
               return (
                 <div key={`${event.pk}`}>


### PR DESCRIPTION
### Summary

Fixed critical frontend issue that broke frontend when a backend endpoint was deleted earlier on down the commit tree from pruning unncessary get_events. I reimplemented the function since it is necessary for the front end to function correctly.

### Test Plan

The frontend now works again, which is all the proof necessary. I traced the root back to an api call that wasn't receiving any data, and then fixed that api call by reimplementing it in the backend.
