### PR TITLE
fixed django external image stuff

### DIFF
--- a/events_backend/app/serializers.py
+++ b/events_backend/app/serializers.py
@@ -59,8 +59,8 @@ class EventSerializer(serializers.ModelSerializer):
         """Convert `username` to lowercase."""
         ret = super().to_representation(instance)
         for media in ret["media"]:
-            # if the link is from fcbk, then it will have fbcdn.net in it so don't do the manual appending stuff
-            if "fbcdn.net" not in media['link']:
+            # if the link is from fcbk or localist, then it will have https:// in it so don't do the manual appending stuff
+            if "https://" not in media["link"] and "http://" not in media["link"]:
                 media["link"] = (
                     "https://"
                     + settings.AWS_STORAGE_BUCKET_NAME


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request allows external images to be returned from the feed endpoint. External images are defined as those stored in the app_media table with an "http://" or "https://" in them

### Test Plan <!-- Required -->

Checked to see if events feed endpoint returned valid image urls

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
Will have to also add this to the restructured version...