### PR TITLE
Added static versioning for android and iOS

### DIFF
--- a/events_backend/app/models.py
+++ b/events_backend/app/models.py
@@ -136,12 +136,6 @@ class Verified_Emails(models.Model):
 #     def __str__(self):
 #         return self.name
 
-class MinimumVersion(models.Model):
-    class Meta:
-        app_label = 'app'
-
-    version = models.IntegerField(unique=True)
-
 
 class Event(models.Model):
     class Meta:

--- a/events_backend/app/serializers.py
+++ b/events_backend/app/serializers.py
@@ -83,13 +83,6 @@ class TagSerializer(serializers.ModelSerializer):
         fields = ("pk", "name")
 
 
-class MinimumVersionSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Tag
-
-        fields = ("version")
-
-
 class UpdatedEventsSerializer(serializers.Serializer):
     events = serializers.JSONField()  # pass in serialized events
     timestamp = serializers.DateTimeField()

--- a/events_backend/app/urls.py
+++ b/events_backend/app/urls.py
@@ -71,8 +71,7 @@ urlpatterns = [
         views.IncrementAttendance.as_view(), name="Increment Attendance"),
     url(r'^attendance/unincrement/(?P<event_id>[0-9]+)/$',
         views.UnincrementAttendance.as_view(), name="Unicrement Attendance"),
-    url(r'^setMinVersion/(?P<version>.*)/$', views.SetMinVersionView.as_view()),
-    url(r'^checkMinVersion/(?P<version>.*)/$',
+    url(r'^checkMinVersion/(?P<version>.*)/(?P<platform>.*)/$',
         views.GetMinVersionView.as_view()),
 
     url(r'^users/$', views.UserList.as_view()),

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -33,7 +33,6 @@ from rest_framework.views import APIView
 
 from .models import (
     Org,
-    MinimumVersion,
     Mobile_User,
     Event,
     Event_Org,
@@ -54,7 +53,6 @@ from .serializers import (
     UpdatedEventsSerializer,
     UpdatedOrgSerializer,
     UserSerializer,
-    MinimumVersionSerializer,
 )
 
 from django.core.mail import send_mail
@@ -793,30 +791,25 @@ class OrgFormView(APIView):
 #                       VERSIONING
 # =============================================================
 
-class SetMinVersionView(APIView):
-
-    permission_classes = ()
-
-    def get(self, request, version):
-        MinimumVersion.objects.all().delete()
-        versionStringWithoutPeriods = version.replace(".", "")
-        versionNumRequest = int(versionStringWithoutPeriods)
-        MinimumVersion.objects.create(version=versionNumRequest).save()
-        return JsonResponse({ 'version': versionNumRequest })
-
 class GetMinVersionView(APIView):
 
     permission_classes = ()
 
-    def get(self, request, version):
-        latestVersion = MinimumVersion.objects.latest('version')
-        versionNum = latestVersion.version
-        versionStringWithoutPeriods = version.replace(".", "")
-        versionNumRequest = int(versionStringWithoutPeriods)
-        if versionNumRequest < versionNum:
-            return JsonResponse({ 'passed': False })
-        else:
-            return JsonResponse({ 'passed': True })
+    def get(self, request, version, platform):
+        minIosVersion = "3.3.5"
+        minAndroidVersion = "3.6.7"
+        plat = platform.lower()
+        versionSplits = version.split(".")
+        if plat == "android":
+            minVersionSplits = minAndroidVersion.split(".")
+        elif plat == "ios":
+            minVersionSplits = minIosVersion.split(".")
+
+        for i in range(0, len(minVersionSplits)):
+            if int(versionSplits[i]) < int(minVersionSplits[i]):
+                return JsonResponse({ 'passed': False })
+
+        return JsonResponse({ 'passed': True })
 
 # =============================================================
 

--- a/events_backend/manage.py
+++ b/events_backend/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import django
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
@@ -8,4 +9,5 @@ if __name__ == "__main__":
         from django.core.management import execute_from_command_line
         execute_from_command_line(sys.argv)
     except ImportError as exc:
+        print(exc)
         print("Failed to import `django.core.management.execute_from_command_line`")

--- a/events_backend/manage.py
+++ b/events_backend/manage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
 import sys
-import django
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")


### PR DESCRIPTION
### Summary <!-- Required -->
Made version checking static by simply changing arbitrary string in code for both ios and android. Additionally, the check version endpoint is now "checkMinVersion/{version num}/{platform}/" where {platform} is "android" or "ios". 

### Test Plan <!-- Required -->
Tested on local, working as anticipated.