### PR TITLE
Auth attendance

### DIFF
--- a/events_backend/app/api_urls.py
+++ b/events_backend/app/api_urls.py
@@ -10,8 +10,6 @@ urlpatterns = [
     # tokens
     url(r'^get_token/(?P<id_token>.*)/?$',
         views.Tokens.as_view({'get': 'get_token'}), name='Get-Token'),
-    url(r'^reset_token/(?P<id_token>.*)/?$',
-        views.Tokens.as_view({'get': 'reset_token'}), name='Reset-Token'),
 
     # login/signup/change login credentials
     url(r"^signup/?$", ensure_csrf_cookie(views.SignUp.as_view()), name="Sign-Up"),

--- a/events_backend/app/api_urls.py
+++ b/events_backend/app/api_urls.py
@@ -8,9 +8,9 @@ from . import views
 
 urlpatterns = [
     # tokens
-    url(r'^get_token/(?P<mobile_id>.*)/?$',
+    url(r'^get_token/(?P<id_token>.*)/?$',
         views.Tokens.as_view({'get': 'get_token'}), name='Get-Token'),
-    url(r'^reset_token/(?P<mobile_id>.*)/?$',
+    url(r'^reset_token/(?P<id_token>.*)/?$',
         views.Tokens.as_view({'get': 'reset_token'}), name='Reset-Token'),
 
     # login/signup/change login credentials

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -402,7 +402,7 @@ class OrgEvents(ViewSet):
 
     def increment_attendance(self, request, event_id, format=None):
         attendance = Attendance.objects.filter(event_id=event_id, user_id=request.user.id)
-        if attendance:
+        if attendance.exists():
             return HttpResponse("Attendance has already been registered for event with ID: " + event_id, status=status.HTTP_200_OK)
         attendance = Attendance(event_id=event_id, user_id=request.user.id)
         attendance.save()
@@ -413,7 +413,7 @@ class OrgEvents(ViewSet):
 
     def decrement_attendance(self, request, event_id, format=None):
         attendance = Attendance.objects.filter(event_id=event_id, user_id=request.user.id)
-        if not attendance:
+        if not attendance.exists():
             return HttpResponse("Attendance was not recorded for event with ID: " + event_id, status=status.HTTP_200_OK)
         attendance.delete()
         event = get_object_or_404(Event, pk=event_id)


### PR DESCRIPTION
### Summary

This diff adds a way to authenticate mobile users.
For now, authentication is only used for attendance tracking.
Later, it can be used to identify whether friends are going to an event, for example.

#### Why?

We want mobile users to be able to say that they are going to an event.
We do not want mobile users to be able to report attendance multiple times.

#### How?

The `get_token` endpoint should be called by mobile users when they open the app.
This "logs" the user in and provides them with a django token.
The mobile app can then supply this token in the headers to authenticate requests like `increment_attendance`.

#### Test Plan

- I playtested using Postman and Apiary. It seems fine so far.
- The [Apiary](https://oldeve.docs.apiary.io/) has been updated with these endpoints.

#### Notes

This removes the reset_token endpoint (just use get_token)

One security problem may be that the django tokens don't expire. If an attacker gets hold of a token, they can report event attendance as that person.
We can tackle that problem by making tokens expire.
