### PR TITLE
remove useless endpoints, fix img upload

### DIFF
--- a/events_backend/app/api_urls.py
+++ b/events_backend/app/api_urls.py
@@ -63,6 +63,4 @@ urlpatterns = [
     # feeds
     url(r'^get_event_feed/?$',
         views.Feeds.as_view({'get': 'get_event_feed'}), name='Get-Event-Feed'),
-
-    url(r"^sign_s3/?$", views.GetSignedRequest.as_view(), name="Get-Signed-Request"),
 ]

--- a/events_backend/app/serializers.py
+++ b/events_backend/app/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from .models import Event, Org, Location, Tag, Org_Tags, Media, Event_Tags, Event_Media
 from django.contrib.auth.models import User
 from django.conf import settings
-
+import re
 
 class OrgSerializer(serializers.ModelSerializer):
     # email = serializers.SerializerMethodField()
@@ -26,12 +26,7 @@ class OrgSerializer(serializers.ModelSerializer):
         """Convert `username` to lowercase."""
         ret = super().to_representation(instance)
         for photo in ret["photo"]:
-            photo["link"] = (
-                "https://"
-                + settings.AWS_STORAGE_BUCKET_NAME
-                + ".s3.amazonaws.com/"
-                + photo["link"]
-            )
+            photo["link"] = "https://" + settings.AWS_S3_CUSTOM_DOMAIN + photo["link"]
         return ret
 
 
@@ -60,13 +55,8 @@ class EventSerializer(serializers.ModelSerializer):
         ret = super().to_representation(instance)
         for media in ret["media"]:
             # if the link is from fcbk or localist, then it will have https:// in it so don't do the manual appending stuff
-            if "https://" not in media["link"] and "http://" not in media["link"]:
-                media["link"] = (
-                    "https://"
-                    + settings.AWS_STORAGE_BUCKET_NAME
-                    + ".s3.amazonaws.com/"
-                    + media["link"]
-                )
+            if not re.match("https*:\/\/", media["link"]):
+                media["link"] = "https://" + settings.AWS_S3_CUSTOM_DOMAIN + media["link"]
         return ret
 
 

--- a/events_backend/app/urls.py
+++ b/events_backend/app/urls.py
@@ -24,8 +24,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('app.api_urls')),
 
-    url(r'^media/(?P<img_id>[0-9]+)/$',
-        views.ImageDetail.as_view(), name='Media Detail'),
     url(r'upload_image_s3/', views.UploadImageS3.as_view(),
         name='Upload Image to Amazon S3'),
 

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -63,14 +63,17 @@ import os
 import re
 
 from math import ceil
+from botocore.exceptions import ClientError
+import logging
 
 User = get_user_model()
 EVENTS_PER_PAGE = 15
 
-
 # =============================================================
 #                    AASA
 # =============================================================
+
+
 class AppleAppSite(APIView):
     permission_classes = (AllowAny,)
 
@@ -93,13 +96,13 @@ class Tokens(ViewSet):
         validated, mobile_id = validate_firebase(id_token)
         if not validated:
             return HttpResponseBadRequest("Invalid ID Token")
-        
+
         mobile_user_set = Mobile_User.objects.filter(mobile_id=mobile_id)
         if mobile_user_set.exists():
             user = User.objects.get(id=mobile_user_set[0].user_id)
             token = get_object_or_404(Token, user=user)
             return JsonResponse({"token": token.key}, status=status.HTTP_200_OK)
-        
+
         # generate username
         username = generateUserName()
         user = User.objects.create_user(username=username)
@@ -368,7 +371,7 @@ class OrgEvents(ViewSet):
             building=eventData["location"]["building"],
             place_id=eventData["location"]["place_id"],
         )
-    
+
         event.name = eventData["name"]
         event.location = loc[0]
         event.start_date = dt.strptime(
@@ -383,7 +386,8 @@ class OrgEvents(ViewSet):
         event.save()
 
         for t in event.tags.all():
-            Event_Tags.objects.get(event_id=eventData["pk"], tags_id=t.id).delete()
+            Event_Tags.objects.get(
+                event_id=eventData["pk"], tags_id=t.id).delete()
 
         for t in eventData["tags"]:
             tag = get_object_or_404(Tag, name=t["label"])
@@ -409,7 +413,8 @@ class OrgEvents(ViewSet):
             return HttpResponse(status=status.HTTP_401_UNAUTHORIZED)
 
     def increment_attendance(self, request, event_id, format=None):
-        attendance = Attendance.objects.filter(event_id=event_id, user_id=request.user.id)
+        attendance = Attendance.objects.filter(
+            event_id=event_id, user_id=request.user.id)
         if attendance.exists():
             return HttpResponse("Attendance has already been registered for event with ID: " + event_id, status=status.HTTP_200_OK)
         attendance = Attendance(event_id=event_id, user_id=request.user.id)
@@ -420,7 +425,8 @@ class OrgEvents(ViewSet):
         return HttpResponse("Attendance incremented for event with ID: " + event_id, status=status.HTTP_200_OK)
 
     def decrement_attendance(self, request, event_id, format=None):
-        attendance = Attendance.objects.filter(event_id=event_id, user_id=request.user.id)
+        attendance = Attendance.objects.filter(
+            event_id=event_id, user_id=request.user.id)
         if not attendance.exists():
             return HttpResponse("Attendance was not recorded for event with ID: " + event_id, status=status.HTTP_200_OK)
         attendance.delete()
@@ -482,164 +488,46 @@ class Feeds(ViewSet):
 #                          MEDIA
 # =============================================================
 
-# TODO: DEAL WITH THIS AFTER SCOTT IS DONE WITH HIS S3 FIX
 
-
-class GetSignedRequest(APIView):
+class UploadImageS3(APIView):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request):
-        S3_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
-        timeString = dt.now().strftime("%Y%m%d_%H%M%S")
-        file_name = (
-            "user_media/"
-            + str(request.user.id)
-            + "/"
-            + timeString
-            + "_"
-            + request.GET.get("file_name")
-        )
-        file_type = request.GET.get("file_type")
-
-        s3 = boto3.client(
-            "s3",
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
-        )
-
-        presigned_post = s3.generate_presigned_post(
-            Bucket=S3_BUCKET,
-            Key=file_name,
-            Fields={"acl": "public-read", "Content-Type": file_type},
-            Conditions=[{"acl": "public-read"}, {"Content-Type": file_type}],
-            ExpiresIn=3600,
-        )
-
-        return JsonResponse(
-            {
-                "data": presigned_post,
-                "url": "https://%s.s3.amazonaws.com/%s" % (S3_BUCKET, file_name),
-            },
-            status=status.HTTP_200_OK,
-        )
-
-
-class ImageDetail(APIView):
-    # TODO: alter classes to token and admin?
-    authentication_classes = ()  # (TokenAuthentication, )
-    permission_classes = ()  # (IsAuthenticated, )
-
-    def get(self, request, img_id, format=None):
-        media = Media.objects.filter(pk=img_id)[0].file.name
-        name, extension = os.path.splitext(media)
-        s3 = S3Connection(settings.AWS_ACCESS_KEY_ID,
-                          settings.AWS_SECRET_ACCESS_KEY)
-        s3bucket = s3.get_bucket(settings.AWS_STORAGE_BUCKET_NAME)
-        s3key = s3bucket.get_key(media)
-        response = HttpResponse(
-            s3key.read(), status=status.HTTP_200_OK, content_type="image/" + extension
-        )  # what if its not jpg
-        response["Content-Disposition"] = "inline; filename=" + media
-        return response
-
-
-def upload_image(s3, bucket_name, filename_path, file_data):
-
-    try:
-        print("\nattempting to upload:")
-        print(filename_path)
-        s3.put_object(Bucket=bucket_name, Key=filename_path, Body=file_data.file)
-    except ClientError as e:
-        logging.error(e)
-        return False, ""
-    finally:
-        return True, filename_path
-
-def make_public(s3, bucket_name, filename_path):
-    try:
-        s3.put_object_acl(ACL="public-read",
-        Bucket=bucket_name)
-    except ClientError as e:
-        logging.error(e)
-        return False
-    finally:
-        return True
-
-class UploadImageS3(APIView):
-    authentication_classes = ()
-    permission_classes = ()
-
     def post(self, request):
-        user_id = str(request.user.id)
-        file_type = request.GET.get("file_type").replace('"', '')
-        uploaded_file_name = request.GET.get("file_name").replace('"', '')
-        
-        fileData = request.data["file"]
-
-        print("reuest data")
-        print(list(request.POST.items()))
+        user_id = request.user.id
+        req_data = request.data["file"]
+        uploaded_file_name = req_data.name
+        file_data = req_data.file
 
         S3_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
-        timeString = dt.now().strftime("%Y%m%d_%H%M%S")
-
-
         s3 = boto3.client(
             "s3",
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
         )
 
+        timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
+        file_name = "user_media/%s/%s_%s" % (user_id,
+                                             timestamp, uploaded_file_name)
+        file_url = "https://%s.s3.amazonaws.com/%s" % (S3_BUCKET, file_name)
 
-        file_name = ("user_media/"
-            + user_id + '/'
-            + timeString
-            + '_'
-            + str(uploaded_file_name))
-
-
-        upload_success, s3_url = upload_image(s3, S3_BUCKET, file_name, fileData)
-
-        file_url = "https://%s.s3.amazonaws.com/%s" % (S3_BUCKET, s3_url)
-
-        make_public_success = False
-        if upload_success:
-
-
-            make_public_success = make_public(s3, S3_BUCKET, file_name)
-
-            if (make_public_success):
-                print("successfully make public")
-            else:
-                print("failure to make public")
-        else:
-            print("failure to make upload")
+        try:
+            s3.put_object(Bucket=S3_BUCKET, Key=file_name,
+                          Body=file_data, ACL="public-read")
+        except ClientError as e:
+            logging.error(e)
 
         return JsonResponse(
             {
-                "potato": 123,
-                "url": file_url,
-                "bucket": S3_BUCKET,
-                "filename": file_name,
-                "upload_success": upload_success,
-                "make_public_success": make_public_success,
-                "s3_url": s3_url
+                "url": file_url
             },
             status=status.HTTP_200_OK
         )
 
-def uploadToS3(file_name, bucket, object_name):
-    s3_client = boto3.client('s3')
-    try:
-        response = s3_client.upload_file(file_name, bucket, object_name)
-    except ClientError as e:
-        logging.error(e)
-        return False
-    return True
-
 # =============================================================
 #                       VERSIONING
 # =============================================================
+
 
 class GetMinVersionView(APIView):
 
@@ -651,7 +539,7 @@ class GetMinVersionView(APIView):
         versionSplits = version.split(".")
         plat = platform.lower()
         if plat != "android" and plat != "ios":
-            return JsonResponse ({ 'passed': False })
+            return JsonResponse({'passed': False})
         if plat == "android":
             minVersionSplits = minAndroidVersion.split(".")
         elif plat == "ios":
@@ -659,9 +547,9 @@ class GetMinVersionView(APIView):
 
         for i in range(0, len(minVersionSplits)):
             if int(versionSplits[i]) >= int(minVersionSplits[i]):
-                return JsonResponse({ 'passed': True })
+                return JsonResponse({'passed': True})
 
-        return JsonResponse({ 'passed': False })
+        return JsonResponse({'passed': False})
 
 
 # =============================================================
@@ -684,15 +572,16 @@ class GetMinVersionView(APIView):
 
         for i in range(0, len(minVersionSplits)):
             if int(versionSplits[i]) < int(minVersionSplits[i]):
-                return JsonResponse({ 'passed': False })
+                return JsonResponse({'passed': False})
 
-        return JsonResponse({ 'passed': True })
+        return JsonResponse({'passed': True})
 
 # =============================================================
 
 # =============================================================
 #                        HELPERS
 # =============================================================
+
 
 def check_login_status(request):
     return JsonResponse({"status": request.user.is_authenticated})

--- a/events_frontend/src/Profile.js
+++ b/events_frontend/src/Profile.js
@@ -64,46 +64,22 @@ class Profile extends Component {
 
   uploadImage(callback) {
     const file = this.state.image;
-    let xhr = new XMLHttpRequest();
-    xhr.open(
-      "GET",
-      "/api/sign_s3/?file_name=" + file.name + "&file_type=" + file.type
-    );
-    xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4) {
-        if (xhr.status === 200) {
-          const response = JSON.parse(xhr.responseText);
-          xhr = new XMLHttpRequest();
-          xhr.open("POST", response.data.url);
 
-          let postData = new FormData();
-          for (let key in response.data.fields) {
-            postData.append(key, response.data.fields[key]);
-          }
-          postData.append("file", file);
+    if (!file.type.includes("image/")) {
+      alert("Could not upload image. Please use a different file type.");
+    }
 
-          xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4) {
-              if (xhr.status === 200 || xhr.status === 204) {
-                console.log("File uploaded!");
-                callback(
-                  response.url
-                    .split("/")
-                    .slice(3)
-                    .join("/")
-                );
-              } else {
-                alert("Could not upload file.");
-              }
-            }
-          };
-          xhr.send(postData);
-        } else {
-          alert("Could not get signed URL.");
-        }
-      }
-    };
-    xhr.send();
+    const data = new FormData();
+    data.append("file", file);
+
+    console.log(file);
+    axios.post(`/api/upload_image_s3/`, data, {
+    }).then(res => {
+      const url = new URL(res.data.url);
+      callback(url.pathname);
+    }).catch(err => {
+      alert(`Could not upload image! Reason: ${err}`);
+    });
   }
 
   async saveProfile() {

--- a/events_frontend/src/Profile.js
+++ b/events_frontend/src/Profile.js
@@ -72,7 +72,6 @@ class Profile extends Component {
     const data = new FormData();
     data.append("file", file);
 
-    console.log(file);
     axios.post(`/api/upload_image_s3/`, data, {
     }).then(res => {
       const url = new URL(res.data.url);

--- a/events_frontend/src/components/CreateEvent.js
+++ b/events_frontend/src/components/CreateEvent.js
@@ -170,24 +170,21 @@ class CreateEvent extends Component {
 
   uploadImage(callback) {
     const file = this.state.image;
-    const fileType = file.type.replace("image/", "");
 
-
-    if (fileType.length == file.type.length) {
-      alert("Could not upload image. Please use a different file type");
+    if (!file.type.includes("image/")) {
+      alert("Could not upload image. Please use a different file type.");
     }
 
-    
     const data = new FormData();
     data.append("file", file);
 
     console.log(file);
-    axios.post(`/api/upload_image_s3/?file_name=${file.name}&file_type=${fileType}`, data, {
+    axios.post(`/api/upload_image_s3/`, data, {
     }).then(res => {
-        console.log(res.data);
-        callback(res.data.url.split("/").slice(3).join("/"));
+      const url = new URL(res.data.url);
+      callback(url.pathname);
     }).catch(err => {
-        alert(`Could not upload image! Reason: ${err}`);
+      alert(`Could not upload image! Reason: ${err}`);
     });
   }
 

--- a/events_frontend/src/components/CreateEvent.js
+++ b/events_frontend/src/components/CreateEvent.js
@@ -178,7 +178,6 @@ class CreateEvent extends Component {
     const data = new FormData();
     data.append("file", file);
 
-    console.log(file);
     axios.post(`/api/upload_image_s3/`, data, {
     }).then(res => {
       const url = new URL(res.data.url);


### PR DESCRIPTION
### Summary <!-- Required -->

Image upload was a mess, so I fixed it up so that it was at least working.

Fixed issues:

- [x] Upload image for profile fixed.
- [x] Removed image upload through presigned URL in favor of Scott's s3 upload endpoint.
- - [ ] We may switch to presigned URL in the future but our implementation at this time didn't seem to work.
- [x] There might have been an issue with long file names? Anyways that issue doesn't seem to appear anymore.
- [x] Extra data was being passed between backend and frontend that were not needed, such as file type.
- [x] Fix security vulnerability where anyone can upload images through our endpoint (without having to login)

### Test Plan <!-- Required -->

Uploaded images for events and profile through the frontend.

![Events](https://i.imgur.com/0meBktI.png)

![Profile](https://i.imgur.com/PYJMSXe.png)

### Notes <!-- Optional -->

Image URLs are now stored beginning with `/`. This is consistent with how [pathnames](https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname) work. The backend has been updated to account for this so this shouldn't break anything.

Right now, the frontend sends the entire image file to the backend, and then the backend uploads the file to S3.
In the future we might want to use the presigned URL feature S3 provides, which lets the frontend directly upload to S3.
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
- Nothing to report at the moment 👀