### PR TITLE
support firebase auth

### DIFF
--- a/events_backend/app/api_urls.py
+++ b/events_backend/app/api_urls.py
@@ -8,7 +8,7 @@ from . import views
 
 urlpatterns = [
     # tokens
-    url(r'^get_token/(?P<id_token>.*)/?$',
+    url(r'^get_token/(?P<fb_token>.*)/?$',
         views.Tokens.as_view({'get': 'get_token'}), name='Get-Token'),
 
     # login/signup/change login credentials

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -703,9 +703,11 @@ def extractToken(header):
 
 
 def generateUserName():
-    # HANDLE user.obects.latest is null case
     # Safe: pk < 2147483647 and max(len(username)) == 150 [16/9/2018]
-    return "user{0}".format(User.objects.latest("pk").pk + 1)
+    user = User.objects.latest("pk")
+    if user is None:
+        return "user0"
+    return "user{0}".format(user.pk + 1)
 
 
 def validate_email(email):

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -101,7 +101,7 @@ class Tokens(ViewSet):
             return JsonResponse({"token": token.key}, status=status.HTTP_200_OK)
         
         # generate username
-        username = generateUserName()
+        username = generate_username()
         user = User.objects.create_user(username=username)
         user.set_unusable_password()
         user.save()
@@ -697,7 +697,7 @@ class GetMinVersionView(APIView):
 def check_login_status(request):
     return JsonResponse({"status": request.user.is_authenticated})
 
-def generateUserName():
+def generate_username():
     # Safe: pk < 2147483647 and max(len(username)) == 150 [16/9/2018]
     try:
         latest_pk = User.objects.latest("pk").pk

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -716,7 +716,7 @@ def validate_email(email):
 def validate_firebase(mobile_id):
     try:
         idinfo = id_token.verify_firebase_token(
-            mobile_id, requests.Request(), audience="propane-melody-209519")
+            mobile_id, requests.Request(), audience=settings.FIREBASE_PROJECT_ID)
         return True, idinfo['sub']
     except ValueError:
         return False, ""

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -697,17 +697,14 @@ class GetMinVersionView(APIView):
 def check_login_status(request):
     return JsonResponse({"status": request.user.is_authenticated})
 
-
-def extractToken(header):
-    return header[header.find(" ") + 1:]
-
-
 def generateUserName():
     # Safe: pk < 2147483647 and max(len(username)) == 150 [16/9/2018]
-    user = User.objects.latest("pk")
-    if user is None:
-        return "user0"
-    return "user{0}".format(user.pk + 1)
+    try:
+        latest_pk = User.objects.latest("pk").pk
+    except User.DoesNotExist:
+        latest_pk = 0
+    return "user{0}".format(latest_pk + 1) 
+    
 
 
 def validate_email(email):

--- a/events_backend/app/views.py
+++ b/events_backend/app/views.py
@@ -89,8 +89,8 @@ class Tokens(ViewSet):
     # TODO: alter classes to token and admin?
     permission_classes = (AllowAny,)
 
-    def get_token(self, request, id_token, format=None):
-        validated, mobile_id = validate_firebase(id_token)
+    def get_token(self, request, fb_token, format=None):
+        validated, mobile_id = validate_firebase(fb_token)
         if not validated:
             return HttpResponseBadRequest("Invalid ID Token")
         
@@ -715,7 +715,8 @@ def validate_email(email):
 
 def validate_firebase(mobile_id):
     try:
-        idinfo = id_token.verify_oauth2_token(mobile_id, requests.Request())
+        idinfo = id_token.verify_firebase_token(
+            mobile_id, requests.Request(), audience="propane-melody-209519")
         return True, idinfo['sub']
     except ValueError:
         return False, ""

--- a/events_backend/project/settings.py
+++ b/events_backend/project/settings.py
@@ -161,7 +161,7 @@ AWS_STORAGE_BUCKET_NAME = config("BUCKETEER_BUCKET_NAME")
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
 AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
 DEFAULT_FILE_STORAGE = "project.storage_backend.MediaStorage"
-
+FIREBASE_PROJECT_ID = "propane-melody-209519"
 
 WEBPACK_LOADER = {
     "DEFAULT": {


### PR DESCRIPTION
### Summary <!-- Required -->

This diff switches to Firebase verification from the previous Google oauth system. This allows anonymous sign ins, which should let us dodge Apple's policy of forcing us to use Apple Sign-in.

#### How it works now

Mobile users will now sign in to and get an id token from Firebase. They will then pass in the Firebase token into the `get_token` endpoint and receive a Django-generated token. The Django token can then be used in Authentication headers for endpoints such as `increment_attendance` for identification.
Basically, not much has changed :)

Other stuff
- renamed `id_token` local variable to `fb_token` to disambiguate from the `id_token` library we are using to verify Firebase tokens.
- put stuff in the constants
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->

Signed in anonymously and used Postman to test the `get_token` endpoint.

<!-- Provide screenshots or point out the additional unit tests -->
![Working](https://i.imgur.com/aeOQ3WU.png)

![Not Working](https://i.imgur.com/931U6Vt.png)

### Breaking Changes  <!-- Optional -->

We can't login with Google anymore after this change; we can only login with users on the "propane-melody" Firebase project.