### PR TITLE
Fix Create Event: Image Uploading and Event Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ If at any point, your database becomes corrupted or you no longer have `db.sqlit
 ## Dependencies & Libraries
  * **[Django Rest Framework](http://www.django-rest-framework.org/) v. 3.8.2** - A Django library that provides powerful authentication protocols.
  * **[Django Simple History](https://django-simple-history.readthedocs.io/en/latest/) v. 2.0** - A Django library that provides methods to store changes to models, and thus, is used to create app-specific event, org. feeds.
-  * [react-avatar-editor](https://www.npmjs.com/package/react-avatar-editor) - Similar to Facebook profile picture. Allows you to crop, resize, and rotate an uploaded image. Use for event image upload in event creation.
-
 
 ## API Documentation
 * [Backend API Documentation](https://cuevents.docs.apiary.io/) - An external Apiary documenting the endpoints for our application.

--- a/events_frontend/src/Profile.js
+++ b/events_frontend/src/Profile.js
@@ -166,7 +166,6 @@ class Profile extends Component {
           onImageChange={image =>
             this.setState({ image: image, imageChanged: true })
           }
-          shape={"rectangle"}
         />
         <TextField
           id="name"

--- a/events_frontend/src/components/CreateEvent.js
+++ b/events_frontend/src/components/CreateEvent.js
@@ -6,7 +6,6 @@ import DialogActions from "@material-ui/core/DialogActions/DialogActions";
 import Button from "@material-ui/core/Button/Button";
 import DialogContent from "@material-ui/core/DialogContent/DialogContent";
 import TextField from "@material-ui/core/TextField/TextField";
-
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, DateTimePicker } from '@material-ui/pickers';
 
@@ -46,7 +45,8 @@ class CreateEvent extends Component {
     visitedLocations: [], // JS Objects of API Call of All Locations
 
     image: null,
-    imageChanged: false
+    imageChanged: false,
+    loading: false
   };
 
   componentDidUpdate(prevProps) {
@@ -83,7 +83,8 @@ class CreateEvent extends Component {
         selected: {
           value: event.location.place_id,
           label: event.location.building
-        }
+        },
+        loading: false
       });
     }
   }
@@ -176,7 +177,6 @@ class CreateEvent extends Component {
     if (fileType.length == file.type.length) {
       alert("Could not upload image. Please use a different file type");
     }
-
     
     const data = new FormData();
     data.append("file", file);
@@ -192,6 +192,8 @@ class CreateEvent extends Component {
   }
 
   async onPublishEvent() {
+    this.setState({loading: true});
+
     let imageUrl = "";
     const location = {
       building: this.state.location,
@@ -231,7 +233,7 @@ class CreateEvent extends Component {
       action: 'Added an Event'
     });
 
-    this.setState({ imageChanged: false });
+    this.setState({ imageChanged: false});
     this.props.onUpdate(eventData);
   }
 
@@ -276,7 +278,6 @@ class CreateEvent extends Component {
             onImageChange={image =>
               this.setState({ image: image, imageChanged: true })
             }
-            shape={"rectangle"}
           />
           <TextField
             label="Event name *"
@@ -346,8 +347,9 @@ class CreateEvent extends Component {
             Cancel
           </Button>
           <Button
+            ref="btn"
             onClick={this.onPublishEvent.bind(this)}
-            disabled={!this.formComplete()}
+            disabled={!this.formComplete() || this.state.loading}
             color="primary"
           >
             Publish Event
@@ -370,8 +372,8 @@ const styles = theme => ({
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-around",
-    width: '36vw',
-    padding: theme.spacing(4)
+    padding: theme.spacing(4),
+    minWidth: "400px"
   }
 });
 

--- a/events_frontend/src/components/EventCard.js
+++ b/events_frontend/src/components/EventCard.js
@@ -68,7 +68,7 @@ const styles = theme => ({
   },
   image: {
     width: "100%",
-    paddingTop: "50%", //2:1 ratio
+    paddingTop: "60%", 
     backgroundColor: theme.palette.primary.main
   },
   actionArea: {

--- a/events_frontend/src/components/ImageUploader.js
+++ b/events_frontend/src/components/ImageUploader.js
@@ -2,42 +2,29 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Button from "@material-ui/core/Button/Button";
 import { withStyles } from "@material-ui/core";
-import AvatarEditor from "react-avatar-editor";
-// import classNames from "classnames";
 
 class ImageUploader extends Component {
-  state = { image_file: null, scaled_image: null };
+  state = { image_file: null, image_preview: null};
 
   onFileChange(e) {
-    const image = e.target.files[0];
-    this.props.onImageChange(image);
-    this.setState({ image_file: image });
+    e.preventDefault();
+    const reader = new FileReader();
+    const file = e.target.files[0];
 
-    if (this.editor) {
-      const canvasScaled = this.editor.getImageScaledToCanvas();
-      this.setState({ scaled_image: canvasScaled });
+    reader.onloadend = () => {
+      this.setState({
+        image_file: file,
+        image_preview: reader.result
+      });
     }
+
+    reader.readAsDataURL(file)
+    this.props.onImageChange(file);
   }
 
   onUploadClick() {
     document.getElementById("fileInput").click();
   }
-
-  classForShape(shape, classes) {
-    switch (shape) {
-      case "circle":
-        return classes.circle;
-      case "rectangle":
-        return classes.rectangle;
-      default:
-        console.log("ImageUploader.classForShape() incorrect shape: " + shape);
-        return null;
-    }
-  }
-
-  setEditorRef = editor => {
-    this.editor = editor;
-  };
 
   render() {
     const { classes } = this.props;
@@ -57,13 +44,9 @@ class ImageUploader extends Component {
             : "Upload image"}
         </Button>
         {this.state.image_file || this.props.image_url ? (
-          <AvatarEditor
-            ref={this.setEditorRef}
-            image={this.state.image_file || this.props.image_url}
-            width={500}
-            height={300}
-            border={0}
-          />
+          <div className={classes.container}>
+            <img className={classes.avatar} src={this.state.image_preview || this.props.image_url}/>
+          </div>
         ) : null}
       </div>
     );
@@ -88,18 +71,15 @@ const styles = theme => ({
   button: {
     width: "100%"
   },
-  imagePreview: {
-    marginTop: theme.spacing(2),
-    backgroundSize: "cover"
+  container: {
+    width: "500px",
+    height: "300px"
   },
-  circle: {
-    width: theme.spacing(50),
-    height: theme.spacing(50),
-    borderRadius: theme.spacing(25)
-  },
-  rectangle: {
+  avatar: {    
     width: "100%",
-    paddingTop: "50%" //2:1 ratio
+    height: "100%",
+    overflow: "hidden",
+    "object-fit": "cover"
   }
 });
 


### PR DESCRIPTION
### Summary 
There were some issues with sizing on different window/browser size. Additionally, I decided to remove our dependence on react-avator-editor for image uploading, since the additional functionalities were unnecessary and confusing (we didn't fully take advantage of its features). It is better to remove any outside dependencies anyways! Lastly, I just added a quick version of disabling the submit event once clicked, so multiple events aren't created.

- [x] Added event button disabling
- [x] Fixed wide screen event popup scrolling issue [CUE-92]
- [x] Removed drag to pan (react-avator-editor) so image is immediately cropped once uploaded [CUE-93]

### Test Plan 
Tested with various image sizes and window sizes. 
Here is an example of how the image gets cropped once uploaded (cannot drag/resize)

ORIGINAL IMAGE
![image0](https://user-images.githubusercontent.com/32003743/95912131-63fdae80-0d70-11eb-92a9-7e622a9a0b67.jpg)

CROPPED IMAGE - Notice how it matches the event card?
<img width="720" alt="Screen Shot 2020-10-13 at 4 25 11 PM" src="https://user-images.githubusercontent.com/32003743/95912382-c5be1880-0d70-11eb-9f7a-dcebb3c59478.png">

### Breaking Changes
Not that I know of... 

### Thoughts on Fixed Cropping
Was wondering what others thought about the insta-crop of images we perform once a picture is uploaded. I decided to make the image 500x300 for now, but we can consider making everything variable size.
