### PR TITLE
remove windows scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,17 +65,13 @@
   },
   "scripts": {
     "start": "npm run frontend & npm run backend",
-    "start-windows": "start /B npm run frontend-windows && npm run backend-windows",
+    "start-windows": "start /B npm run frontend && npm run backend",
     "frontend": "webpack --config events_frontend/webpack.dev.js --watch",
-    "frontend-windows": "webpack --config \"events_frontend\\webpack.dev.js\" --watch",
     "lint": "eslint .",
     "backend": "python3 events_backend/manage.py runserver",
-    "backend-windows": "python3 \"events_backend\\manage.py\" runserver",
     "build": "webpack --config events_frontend/webpack.prod.js",
-    "build-windows": "webpack --config \"events_frontend\\webpack.prod.js\"",
     "heroku-postbuild": "npm run build && python3 events_backend/manage.py collectstatic --noinput",
-    "python-migrate": "python3 events_backend/manage.py makemigrations app && python events_backend/manage.py migrate",
-    "python-migrate-windows": "python3 \"events_backend\\manage.py\" makemigrations app && python \"events_backend\\manage.py\" migrate"
+    "python-migrate": "python3 events_backend/manage.py makemigrations app && python3 events_backend/manage.py migrate"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
### Summary <!-- Required -->

We have Windows versions of each script in `package.json` which adds quotes to and uses the back slash instead of the the forward slash in file paths.

As a Windows user, I have no problem running the regular version of the scripts on `pwsh`.

I think that whatever required this workaround is no longer an issue on Windows, hopefully other devs that use Windows can confirm.

Also I updated the `python-migrate` script to use `python3` instead of `python`, which is what the rest of the scripts use. In some cases `python` might be Python 2.x so we want to be consistent.

### Test Plan

I was able to replicate intended behavior by using the regular versions of the deleted Windows scripts.